### PR TITLE
Add RatePay panels to Shopware.apps.Order.view.detail.Window panel wi…

### DIFF
--- a/Views/backend/rpay_ratepay_orderdetail/backend/order/view/detail/ratepaydetailorder.js
+++ b/Views/backend/rpay_ratepay_orderdetail/backend/order/view/detail/ratepaydetailorder.js
@@ -22,7 +22,7 @@ Ext.define('Shopware.apps.Order.view.detail.ratepaydetailorder', {
         var tabPanel = me.callParent(arguments);
 
         if (me.isRatePAYOrder()) {
-            tabPanel = me.createRatePAYTabPanel();
+            tabPanel = me.createRatePAYTabPanel(tabPanel);
         }
 
         return tabPanel;
@@ -44,39 +44,15 @@ Ext.define('Shopware.apps.Order.view.detail.ratepaydetailorder', {
     },
 
     /**
-     * Creates the tab panel for the detail page.
+     * Adds the tab panels for the detail page.
      * @return Ext.tab.Panel
      */
-    createRatePAYTabPanel: function () {
+    createRatePAYTabPanel: function (tabPanel) {
         var me = this;
 
-        return Ext.create('Ext.tab.Panel', {
-            name: 'main-tab',
-            items: [
-                Ext.create('Shopware.apps.Order.view.detail.Overview', {
-                    title: me.snippets.overview,
-                    record: me.record,
-                    orderStatusStore: me.orderStatusStore,
-                    paymentStatusStore: me.paymentStatusStore
-                }), Ext.create('Shopware.apps.Order.view.detail.Detail', {
-                    title: me.snippets.details,
-                    record: me.record,
-                    paymentsStore: me.paymentsStore,
-                    shopsStore: me.shopsStore,
-                    countriesStore: me.countriesStore
-                }), Ext.create('Shopware.apps.Order.view.detail.Communication', {
-                    title: me.snippets.communication,
-                    record: me.record
-                }), Ext.create('Shopware.apps.Order.view.detail.Document', {
-                    record: me.record,
-                    documentTypesStore: me.documentTypesStore
-                }), Ext.create('Shopware.apps.Order.view.detail.OrderHistory', {
-                    title: me.snippets.history,
-                    historyStore: me.historyStore,
-                    record: me.record,
-                    orderStatusStore: me.orderStatusStore,
-                    paymentStatusStore: me.paymentStatusStore
-                }), Ext.create('Shopware.apps.Order.view.detail.ratepayarticlemanagement', {
+        // Add RatePay panels to the existing Shopware Order panels
+        tabPanel.add([
+            Ext.create('Shopware.apps.Order.view.detail.ratepayarticlemanagement', {
                     title: '{s namespace=RatePAY name=tabarticlemanagement}Artikelverwaltung{/s}',
                     record: me.record,
                     orderStatusStore: me.orderStatusStore,
@@ -91,8 +67,9 @@ Ext.define('Shopware.apps.Order.view.detail.ratepaydetailorder', {
                     orderStatusStore: me.orderStatusStore,
                     paymentStatusStore: me.paymentStatusStore
                 })
-            ]
-        });
+        ]);
+
+        return tabPanel;
     }
 
 });


### PR DESCRIPTION
This pull request contains a fix for the overriding of the Shopware.apps.Order.view.detail.Window tab panels. 

Issue explained here: https://github.com/ratepay/shopware5-module/issues/1