### PR TITLE
Showpare 5.2 getBirthday fix

### DIFF
--- a/Component/Mapper/ModelFactory.php
+++ b/Component/Mapper/ModelFactory.php
@@ -166,7 +166,7 @@
 
                 $company = $checkoutAddressBilling->getCompany();
                 if (empty($company)) {
-                    $dateOfBirth = $shopUser->getBilling()->getBirthday()->format("Y-m-d");
+                    $dateOfBirth = $shopUser->getBirthday()->format("Y-m-d"); // doesn't work from shopware 5.2 onwards. See line 155.
                 }
                 $merchantCustomerId = $shopUser->getBilling()->getNumber();
             }


### PR DESCRIPTION
doesn't work in from shopware 5.2 onwards. See line 155.