### PR TITLE
RATEPLUG-33: fix namespaces configservice && dfpservice

### DIFF
--- a/Bootstrapping/Events/BackendOrderControllerSubscriber.php
+++ b/Bootstrapping/Events/BackendOrderControllerSubscriber.php
@@ -9,7 +9,7 @@ use RpayRatePay\Component\Service\Logger;
 use Shopware\Models\Customer\Customer;
 use Shopware\Models\Order\Order;
 use RpayRatePay\Component\Service\ConfigLoader;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\DfpService;
+use RpayRatePay\Services\DfpService;
 use SwagBackendOrder\Components\Order\Struct\OrderStruct;
 
 class BackendOrderControllerSubscriber implements \Enlight\Event\SubscriberInterface

--- a/Bootstrapping/Events/TemplateExtensionSubscriber.php
+++ b/Bootstrapping/Events/TemplateExtensionSubscriber.php
@@ -3,8 +3,8 @@
 namespace RpayRatePay\Bootstrapping\Events;
 
 use RpayRatePay\Component\Model\ShopwareCustomerWrapper;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ConfigService;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\DfpService;
+use RpayRatePay\Services\ConfigService;
+use RpayRatePay\Services\DfpService;
 
 class TemplateExtensionSubscriber implements \Enlight\Event\SubscriberInterface
 {

--- a/Bootstrapping/ShopConfigSetup.php
+++ b/Bootstrapping/ShopConfigSetup.php
@@ -5,7 +5,7 @@ namespace RpayRatePay\Bootstrapping;
 use RpayRatePay\Component\Service\RatepayConfigWriter;
 use RpayRatePay\Models\ProfileConfig;
 use Shopware\Models\Shop\Shop;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ConfigService;
+use RpayRatePay\Services\ConfigService;
 
 class ShopConfigSetup extends Bootstrapper
 {

--- a/Component/Mapper/ModelFactory.php
+++ b/Component/Mapper/ModelFactory.php
@@ -8,7 +8,7 @@ use RpayRatePay\Component\Service\SessionLoader;
 use RpayRatePay\Component\Service\Logger;
 use RpayRatePay\Component\Service\ShopwareUtil;
 use RpayRatePay\Component\Service\ConfigLoader;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ProfileConfigService;
+use RpayRatePay\Services\ProfileConfigService;
 
 /**
  * This program is free software; you can redistribute it and/or modify it under the terms of

--- a/Component/Service/ConfigLoader.php
+++ b/Component/Service/ConfigLoader.php
@@ -2,8 +2,8 @@
 
 namespace RpayRatePay\Component\Service;
 
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ConfigService;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ProfileConfigService;
+use RpayRatePay\Services\ConfigService;
+use RpayRatePay\Services\ProfileConfigService;
 
 class ConfigLoader
 {

--- a/Component/Service/RatepayConfigWriter.php
+++ b/Component/Service/RatepayConfigWriter.php
@@ -4,7 +4,7 @@ namespace RpayRatePay\Component\Service;
 
 use RpayRatePay\Models\ProfileConfig;
 use Shopware\Components\Model\ModelManager;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ProfileConfigService;
+use RpayRatePay\Services\ProfileConfigService;
 
 class RatepayConfigWriter
 {

--- a/Component/Service/SessionLoader.php
+++ b/Component/Service/SessionLoader.php
@@ -6,7 +6,7 @@ use RatePAY\Service\Math;
 use RpayRatePay\Component\Mapper\BankData;
 use RpayRatePay\Component\Mapper\PaymentRequestData;
 use RpayRatePay\Component\Model\ShopwareCustomerWrapper;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\DfpService;
+use RpayRatePay\Services\DfpService;
 
 class SessionLoader
 {

--- a/Controller/backend/RpayRatepayBackendOrder.php
+++ b/Controller/backend/RpayRatepayBackendOrder.php
@@ -23,8 +23,8 @@ use RpayRatePay\Component\Service\SessionLoader;
 use RpayRatePay\Component\Service\ConfigLoader;
 use RpayRatePay\Component\Service\Logger;
 use RpayRatePay\Models\ProfileConfig;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Models\ConfigRepository;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ConfigService;
+use RpayRatePay\Models\ConfigRepository;
+use RpayRatePay\Services\ConfigService;
 
 class Shopware_Controllers_Backend_RpayRatepayBackendOrder extends Shopware_Controllers_Backend_ExtJs
 {

--- a/Controller/frontend/RpayRatepay.php
+++ b/Controller/frontend/RpayRatepay.php
@@ -24,9 +24,9 @@ use Shopware\Components\CSRFWhitelistAware;
 use RpayRatePay\Component\Service\PaymentProcessor;
 use RpayRatePay\Component\Model\ShopwareCustomerWrapper;
 use RpayRatePay\Component\Service\Logger;
-use \RpayRatePay\Component\Service\ConfigLoader;
-use \Shopware\Plugins\Community\Frontend\RpayRatePay\Services\DfpService;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ProfileConfigService;
+use RpayRatePay\Component\Service\ConfigLoader;
+use RpayRatePay\Services\DfpService;
+use RpayRatePay\Services\ProfileConfigService;
 
 class Shopware_Controllers_Frontend_RpayRatepay extends Shopware_Controllers_Frontend_Payment implements CSRFWhitelistAware
 {

--- a/Models/ConfigRepository.php
+++ b/Models/ConfigRepository.php
@@ -1,15 +1,12 @@
 <?php
 
-
-namespace Shopware\Plugins\Community\Frontend\RpayRatePay\Models;
-
+namespace RpayRatePay\Models;
 
 use RpayRatePay\Models\ProfileConfig;
 use Shopware\Components\Model\ModelRepository;
 
 class ConfigRepository extends ModelRepository
 {
-
     /**
      * @param int $shopId
      * @param string $countryCode
@@ -34,5 +31,4 @@ class ConfigRepository extends ModelRepository
 
         return $qb->getQuery()->getOneOrNullResult();
     }
-
 }

--- a/Models/ProfileConfig.php
+++ b/Models/ProfileConfig.php
@@ -6,12 +6,11 @@ use Doctrine\ORM\Mapping as ORM;
 use Shopware\Components\Model\ModelEntity;
 
 /**
- * @ORM\Entity(repositoryClass="Shopware\Plugins\Community\Frontend\RpayRatePay\Models\ConfigRepository")
+ * @ORM\Entity(repositoryClass="RpayRatePay\Models\ConfigRepository")
  * @ORM\Table(name="rpay_ratepay_config")
  */
 class ProfileConfig extends ModelEntity
 {
-
     /**
      * @var int
      * @ORM\Id()

--- a/Services/ConfigService.php
+++ b/Services/ConfigService.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace RpayRatePay\Services;
-
 
 use Shopware\Components\Model\ModelManager;
 use Shopware\Components\Plugin\CachedConfigReader;
@@ -11,7 +9,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class ConfigService
 {
-
     //TODO remove if plugin is moved to SW5.2 plugin engine
     private static $instance = null;
     /**
@@ -23,7 +20,8 @@ class ConfigService
      */
     protected $modelManager;
 
-    public static function getInstance(){
+    public static function getInstance()
+    {
         return self::$instance = (self::$instance ? : new self(Shopware()->Container()));
     }
 
@@ -37,7 +35,8 @@ class ConfigService
      * @param Shop|int $shop
      * @return |null
      */
-    public function getDfpSnippetId($shop) {
+    public function getDfpSnippetId($shop)
+    {
         return $this->getConfig('ratepay/dfp/snippet_id', 'ratepay', $shop);
     }
 
@@ -76,7 +75,8 @@ class ConfigService
      * @param Shop|int $shop
      * @return |null
      */
-    public function getConfig($configKey, $default = null, $shop = null) {
+    public function getConfig($configKey, $default = null, $shop = null)
+    {
 
         $config = $this->getAllConfig($shop);
         return isset($config[$configKey]) ? $config[$configKey] : $default;

--- a/Services/ConfigService.php
+++ b/Services/ConfigService.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Shopware\Plugins\Community\Frontend\RpayRatePay\Services;
+namespace RpayRatePay\Services;
 
 
 use Shopware\Components\Model\ModelManager;

--- a/Services/DfpService.php
+++ b/Services/DfpService.php
@@ -1,7 +1,7 @@
 <?php
 
 
-namespace Shopware\Plugins\Community\Frontend\RpayRatePay\Services;
+namespace RpayRatePay\Services;
 
 
 use Shopware\Components\DependencyInjection\Container;

--- a/Services/DfpService.php
+++ b/Services/DfpService.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace RpayRatePay\Services;
-
 
 use Shopware\Components\DependencyInjection\Container;
 
 /**
  * ServiceClass for device fingerprinting
  * Class DfpService
- * @package Shopware\Plugins\Community\Frontend\RpayRatePay\Services
+ * @package RpayRatePay\Services
  */
 class DfpService
 {

--- a/Services/ProfileConfigService.php
+++ b/Services/ProfileConfigService.php
@@ -1,15 +1,12 @@
 <?php
 
-
-namespace Shopware\Plugins\Community\Frontend\RpayRatePay\Services;
-
+namespace RpayRatePay\Services;
 
 use RpayRatePay\Models\ProfileConfig;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Models\ConfigRepository;
+use RpayRatePay\Models\ConfigRepository;
 
 class ProfileConfigService
 {
-
     /**
      * @param string$countryCode
      * @param int $shopId
@@ -17,11 +14,11 @@ class ProfileConfigService
      * @param boolean $isBackend
      * @return ProfileConfig|null
      */
-    public static function getProfileConfig($countryCode, $shopId, $isZeroPercentInstallment, $isBackend) {
+    public static function getProfileConfig($countryCode, $shopId, $isZeroPercentInstallment, $isBackend)
+    {
 
         /** @var ConfigRepository $repo */
         $repo = Shopware()->Models()->getRepository(ProfileConfig::class);
         return $repo->findConfiguration($shopId, $countryCode, $isZeroPercentInstallment, $isBackend);
     }
-
 }

--- a/Views/responsive/frontend/installment/php/PiRatepayRateCalcData.php
+++ b/Views/responsive/frontend/installment/php/PiRatepayRateCalcData.php
@@ -12,15 +12,14 @@
 
     //do i need a require here?
     use RpayRatePay\Component\Model\ShopwareCustomerWrapper;
-use RpayRatePay\Models\ProfileConfig;
-use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ProfileConfigService;
+    use RpayRatePay\Models\ProfileConfig;
+    use RpayRatePay\Services\ProfileConfigService;
 
-/**
+    /**
      * Developer needs to specify how the Calculator gets the Data
      */
     class PiRatepayRateCalcData implements PiRatepayRateCalcDataInterface
     {
-
         /**
          * @return ProfileConfig
          */
@@ -225,5 +224,4 @@ use Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ProfileConfigServic
         {
             return Shopware()->Front()->Request()->getPost($var, '');
         }
-
     }


### PR DESCRIPTION
Wrong namespaces used

The plugin is not compatible with Shopware 5.6.
If the plugin is installed, the home page will throw a fatal error. This pull request fixes wrong paths.

For example:

Fatal error: Uncaught Error: Class 'Shopware\Plugins\Community\Frontend\RpayRatePay\Services\ConfigService' not found in /project/Plugins/Community/Frontend/RpayRatePay/Bootstrapping/Events/TemplateExtensionSubscriber.php:29